### PR TITLE
[FEAT][FIX] 달력 선택 날짜로 포커싱, 오류 Toast 부모 위젯 build중 띄어지는 문제, 회원가입 Respone 변경 반영

### DIFF
--- a/lib/constants/app_colors.dart
+++ b/lib/constants/app_colors.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
 
 class AppColors {
-  static const Color primary = Color(0xFFCAE4C1);
   static const Color primaryLight = Color(0XFFF8FAED);
+  static const Color primary = Color(0xFFCAE4C1);
+  static const Color primaryDark = Color(0xFFA4D593);
   static const Color yellow = Color(0xFFFFF8C1);
   static const Color greyLight = Color(0xFFF1F1F1);
   static const Color greyMedium = Color(0xFFE0E0E0);
@@ -10,4 +11,5 @@ class AppColors {
   static const Color greyDark = Color(0xFF7B7B7B);
   static const Color redLight = Color(0XFFFFABB8);
   static const Color redMedium = Color(0XFFEA7373);
+  static const Color blue = Color(0XFF388697);
 }

--- a/lib/data/authentication/auth_repository.dart
+++ b/lib/data/authentication/auth_repository.dart
@@ -53,18 +53,9 @@ class AuthRepository {
   Future<void> register({required RegisterForm form}) async {
     try {
       final uri = _api.auth.register();
-      final body = await _apiClient.post(
+      await _apiClient.post(
         uri,
         body: form.toJson(),
-      );
-      final token = Token.fromJson(body);
-      if (token.refresh == null) {
-        const message = 'Refresh Token is null';
-        throw Exception(message);
-      }
-      await _tokenRepo.saveTokens(
-        accessToken: token.access,
-        refreshToken: token.refresh!,
       );
     } catch (e, stackTrace) {
       _errorHandler(e, stackTrace);

--- a/lib/presentation/screens/my_page_screen.dart
+++ b/lib/presentation/screens/my_page_screen.dart
@@ -2,9 +2,7 @@ import 'dart:math';
 
 import 'package:auto_route/auto_route.dart';
 import 'package:dropdown_button2/dropdown_button2.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:google_fonts/google_fonts.dart';

--- a/lib/presentation/screens/record_screen/my_record_tab.dart
+++ b/lib/presentation/screens/record_screen/my_record_tab.dart
@@ -86,6 +86,7 @@ class _MyRecordTabState extends ConsumerState<MyRecordTab>
         AppCalendar(
           width: _calendarWidth,
           height: _calendarHeight,
+          focusedDay: _selectedDate,
           selectedDay: _selectedDate,
           onSelected: (date) {
             _onDateSelected(date, recordsState);
@@ -1787,10 +1788,7 @@ class _TimeFormState extends State<_TimeForm> {
       height: widget.height,
       child: GestureDetector(
         onTap: () async {
-          final TimeOfDay? timeOfDay = await showTimePicker(
-            context: context,
-            initialTime: selectedTime,
-          );
+          final TimeOfDay? timeOfDay = await _showTimePicker();
           if (timeOfDay != null) {
             setState(() {
               selectedTime = timeOfDay;
@@ -1817,6 +1815,34 @@ class _TimeFormState extends State<_TimeForm> {
           ),
         ),
       ),
+    );
+  }
+
+  Future<TimeOfDay?> _showTimePicker() async {
+    return await showTimePicker(
+      context: context,
+      initialTime: selectedTime,
+      initialEntryMode: TimePickerEntryMode.inputOnly,
+      builder: (context, child) {
+        return Theme(
+          data: ThemeData.light().copyWith(
+            colorScheme: ColorScheme.light(
+              primary: AppColors.primaryDark,
+              // change the text color
+              onSurface: AppColors.greyDark,
+              background: Colors.white,
+              outline: AppColors.greyDark,
+            ),
+            // button colors
+            buttonTheme: ButtonThemeData(
+              colorScheme: ColorScheme.light(
+                primary: Colors.teal,
+              ),
+            ),
+          ),
+          child: child!,
+        );
+      },
     );
   }
 }

--- a/lib/presentation/screens/record_screen/my_record_tab.dart
+++ b/lib/presentation/screens/record_screen/my_record_tab.dart
@@ -7,7 +7,6 @@ import 'package:intl/intl.dart';
 import 'package:table_calendar/table_calendar.dart';
 import 'package:untitled/presentation/screens/shared/exception_handler_on_view.dart';
 import 'package:untitled/presentation/viewmodels/record/record_screen_viewmodel.dart';
-import 'package:untitled/utils/app_logger.dart';
 import 'package:untitled/utils/snack_bar_helper.dart';
 import 'package:untitled/utils/time_of_day_utils.dart';
 import 'package:untitled/utils/toast_helper.dart';
@@ -346,12 +345,10 @@ class _MyRecordTabState extends ConsumerState<MyRecordTab>
   }
 
   void _updateRecord(RecordState recordState) {
-    logger.wtf('updateRecord');
     ref
         .read(recordControllerProvider.notifier)
         .updateRecord(recordState: recordState)
         .whenComplete(() {
-      logger.wtf("updateRecord complete");
       _closeBottomSheet();
       _showRecordDetail(
         AsyncValue.data([recordState]),

--- a/lib/presentation/screens/shared/exception_handler_on_view.dart
+++ b/lib/presentation/screens/shared/exception_handler_on_view.dart
@@ -54,7 +54,9 @@ void _handleNotificationException(
       break;
 
     case (NotificationType.error):
-      ToastHelper.showErrorOccurred(context);
+      WidgetsBinding.instance.addPostFrameCallback((_) async {
+        ToastHelper.showErrorOccurred(context);
+      });
       break;
   }
 }

--- a/lib/presentation/screens/sign_up_screen.dart
+++ b/lib/presentation/screens/sign_up_screen.dart
@@ -903,7 +903,7 @@ class _SignUpScreenState extends ConsumerState<SignUpScreen> {
     void onSuccess() {
       SnackBarHelper.showTextSnackBar(context, "회원가입이 완료되었습니다.");
       AutoRouter.of(context).popUntilRoot();
-      AutoRouter.of(context).replace(MemberHomeRoute());
+      AutoRouter.of(context).replace(LoginRoute());
     }
 
     ref.listen(

--- a/lib/presentation/viewmodels/record/record_screen_viewmodel.dart
+++ b/lib/presentation/viewmodels/record/record_screen_viewmodel.dart
@@ -1,7 +1,5 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-import '../../../utils/app_logger.dart';
-
 part 'record_screen_viewmodel.g.dart';
 
 enum RecordScreenBottomSheetState {
@@ -29,16 +27,12 @@ class RecordScreenViewmodel extends _$RecordScreenViewmodel {
   }
 
   void closeBottomSheet() {
-    logger.wtf('vm: closeBottomSheet',
-        error: Exception(), stackTrace: StackTrace.current);
     state = RecordScreenState(
       bottomSheetState: RecordScreenBottomSheetState.none,
     );
   }
 
   void openBottomSheet(RecordScreenBottomSheetState bottomSheetState) {
-    logger.wtf('vm: openBottomSheet',
-        error: Exception(), stackTrace: StackTrace.current);
     state = RecordScreenState(
       bottomSheetState: bottomSheetState,
     );

--- a/lib/widgets/app_calendar.dart
+++ b/lib/widgets/app_calendar.dart
@@ -19,6 +19,7 @@ class AppCalendar extends StatefulWidget {
   final double width;
   final double height;
   final DateTime? selectedDay;
+  final DateTime? focusedDay;
   final void Function(DateTime)? onSelected;
   late final LinkedHashMap<DateTime, CalendarEvent> events;
 
@@ -27,6 +28,7 @@ class AppCalendar extends StatefulWidget {
     required this.width,
     required this.height,
     this.selectedDay,
+    this.focusedDay,
     this.onSelected,
     Map<DateTime, CalendarEvent>? eventsSource,
   }) {
@@ -52,12 +54,14 @@ class _AppCalendarState extends State<AppCalendar> {
   late TextStyle _todayTextStyle;
 
   DateTime? _selectedDay;
+  DateTime? _focusedDay;
 
   @override
   void initState() {
     super.initState();
 
     _selectedDay = widget.selectedDay;
+    _focusedDay = widget.focusedDay ?? _today;
   }
 
   @override
@@ -65,6 +69,7 @@ class _AppCalendarState extends State<AppCalendar> {
     super.didUpdateWidget(oldWidget);
 
     _selectedDay = widget.selectedDay;
+    _focusedDay = widget.focusedDay ?? _today;
   }
 
   @override
@@ -74,7 +79,7 @@ class _AppCalendarState extends State<AppCalendar> {
       width: widget.width,
       height: widget.height,
       child: TableCalendar(
-        focusedDay: _today,
+        focusedDay: _focusedDay ?? _today,
         shouldFillViewport: true,
         firstDay: DateTime(2015),
         lastDay: DateTime(2050),


### PR DESCRIPTION
# Description
- 달력 선택 날짜로 포커싱되도록 수정했습니다. 
- 오류 Toast 메세지가 부모 위젯 build중 띄어지는 문제를 해결하였습니다.
- 회원가입 Respone 변경 반영하였습니다. 이제 회원가입 완료 시 로그인 화면으로 넘어갑니다.

# Done
- [x] 달력 다른 달의 날짜 선택 시에 선택한 날짜에 포커싱이 유지되게 하기
- [x] 마이페이지 화면에 접속 할 시에 API 호출이 실패 시 setState while build 문제 해결
- [x] 회원가입 성공 후 토큰 저장하지 않게 수정
- [x] 회원가입 성공 후 바로 로그인 창으로 넘어갈 수 있게 수정

# Related Issues
close #27 
close #28
close #29 
