### PR TITLE
[FIX] Issues 35, 36

### DIFF
--- a/lib/presentation/screens/my_page_screen.dart
+++ b/lib/presentation/screens/my_page_screen.dart
@@ -204,7 +204,7 @@ class _MyPageScreenState extends ConsumerState<MyPageScreen> {
 }
 
 class _MyPageAppBar extends StatelessWidget {
-  final MyPageState _userInfo;
+  final MyPageStateModel _userInfo;
   // ------------------------------------------------------------------------ //
   // Size Variables - Must init in build() !                                  //
   // ------------------------------------------------------------------------ //
@@ -213,7 +213,7 @@ class _MyPageAppBar extends StatelessWidget {
 
   _MyPageAppBar({
     super.key,
-    required MyPageState userInfo,
+    required MyPageStateModel userInfo,
   }) : _userInfo = userInfo;
 
   @override
@@ -444,7 +444,7 @@ class _LogOutPopUp extends ConsumerWidget {
    */
 
 class _MyPageAppBarFlexibleSpace extends StatelessWidget {
-  final MyPageState _userInfo;
+  final MyPageStateModel _userInfo;
   final double _toolbarHeight;
   final double _expandedHeight;
 
@@ -461,7 +461,7 @@ class _MyPageAppBarFlexibleSpace extends StatelessWidget {
     super.key,
     required double toolbarHeight,
     required double expandedHeight,
-    required MyPageState userInfo,
+    required MyPageStateModel userInfo,
   })  : _toolbarHeight = toolbarHeight,
         _expandedHeight = expandedHeight,
         _userInfo = userInfo;
@@ -538,13 +538,13 @@ class _MyPageAppBarFlexibleSpace extends StatelessWidget {
 class _MyPageAppBarFlexibleSpaceIntroduction extends StatelessWidget {
   final double _introductionWidth;
   final double _introductionHeight;
-  final MyPageState _userInfo;
+  final MyPageStateModel _userInfo;
 
   const _MyPageAppBarFlexibleSpaceIntroduction({
     super.key,
     required double introductionWidth,
     required double introductionHeight,
-    required MyPageState userInfo,
+    required MyPageStateModel userInfo,
   })  : _introductionWidth = introductionWidth,
         _introductionHeight = introductionHeight,
         _userInfo = userInfo;

--- a/lib/presentation/screens/record_screen/ranking_tab.dart
+++ b/lib/presentation/screens/record_screen/ranking_tab.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:untitled/constants/app_colors.dart';
 import 'package:untitled/constants/app_constants.dart';
 import 'package:untitled/constants/size_config.dart';
 import 'package:untitled/presentation/screens/shared/exception_handler_on_view.dart';
@@ -367,15 +368,15 @@ class RankingCriteriaButton extends StatelessWidget {
         },
         icon: SvgPicture.asset(
           'assets/icons/question_mark_circle.svg',
-          color: Color(0xFFE0E0E0),
-          width: AppSize.of(context).safeBlockHorizontal * 2.75,
+          color: AppColors.greyDark,
+          width: AppSize.of(context).safeBlockHorizontal * 3.5,
         ),
         label: Text(
           '랭킹 기준',
           style: GoogleFonts.inter(
             textStyle: TextStyle(
-              color: Color(0xFFE0E0E0),
-              fontSize: AppSize.of(context).safeBlockHorizontal * 2.75,
+              color: AppColors.greyDark,
+              fontSize: AppSize.of(context).safeBlockHorizontal * 3.5,
               fontWeight: FontWeight.w500,
             ),
           ),
@@ -392,14 +393,24 @@ class RankingCriteriaPopup extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
-      title: Text("랭킹 기준"),
+      title: Text(
+        "랭킹 기준",
+        style: TextStyle(fontSize: AppSize.of(context).font.headline1),
+      ),
       content: Text(
         "본인의 난이도 문제: 1점\n본인의 난이도보다 낮은 문제: 0.5점\n본인의 난이도보다 높은 문제: 2점",
-        style: TextStyle(color: Color(0xFF7B7B7B)),
+        style: TextStyle(
+          color: AppColors.greyDark,
+          fontSize: AppSize.of(context).font.content,
+        ),
       ),
       backgroundColor: Color(0xFFFFFFFF),
       elevation: 0,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(
+          AppSize.of(context).safeBlockHorizontal * 6.0,
+        ),
+      ),
     );
   }
 }
@@ -506,7 +517,8 @@ class WeeklyRankingPageView extends StatelessWidget {
         child: Text(
           "랭킹이 없어요 😢",
           style: TextStyle(
-            fontSize: AppSize.of(context).font.headline2,
+            color: AppColors.greyMediumDark,
+            fontSize: AppSize.of(context).font.headline3,
           ),
         ),
       );
@@ -596,7 +608,8 @@ class AllRankingPageView extends StatelessWidget {
         child: Text(
           "랭킹이 없어요 😢",
           style: TextStyle(
-            fontSize: AppSize.of(context).font.headline2,
+            color: AppColors.greyMediumDark,
+            fontSize: AppSize.of(context).font.headline3,
           ),
         ),
       );

--- a/lib/presentation/screens/record_screen/record_screen.dart
+++ b/lib/presentation/screens/record_screen/record_screen.dart
@@ -54,12 +54,12 @@ class _RecordScreenState extends ConsumerState<RecordScreen>
   Widget build(BuildContext context) {
     final List<Widget> tabs = [
       Tab(
-        height: AppSize.of(context).safeBlockHorizontal * 13,
+        height: AppSize.of(context).safeBlockHorizontal * 10,
         child: Text("내 기록",
             style: TextStyle(fontSize: AppSize.of(context).font.headline3)),
       ),
       Tab(
-        height: AppSize.of(context).safeBlockHorizontal * 13,
+        height: AppSize.of(context).safeBlockHorizontal * 10,
         child: Text("랭킹",
             style: TextStyle(fontSize: AppSize.of(context).font.headline3)),
       ),
@@ -71,24 +71,26 @@ class _RecordScreenState extends ConsumerState<RecordScreen>
         bottom: false,
         child: Column(
           children: [
-            TabBar(
-              tabs: tabs,
-              controller: _tabController,
-              //physics: NeverScrollableScrollPhysics(),
-              indicatorColor: Color(0xffcae4c1),
-              indicatorWeight: 3,
-              labelColor: Colors.black,
-              unselectedLabelColor: Colors.grey,
-              onTap: (_) {
-                if (ref.read(recordScreenViewmodelProvider).bottomSheetState !=
-                    RecordScreenBottomSheetState.none) {
-                  ref
-                      .read(recordScreenViewmodelProvider.notifier)
-                      .closeBottomSheet();
-                  Navigator.of(context).pop();
-                }
-              },
-            ),
+            // TabBar(
+            //   tabs: tabs,
+            //   controller: _tabController,
+            //   isScrollable: false,
+            //   //physics: NeverScrollableScrollPhysics(),
+            //   indicatorColor: Color(0xffcae4c1),
+            //   indicatorWeight: 3,
+            //   labelColor: Colors.black,
+            //   unselectedLabelColor: Colors.grey,
+            //
+            //   onTap: (_) {
+            //     if (ref.read(recordScreenViewmodelProvider).bottomSheetState !=
+            //         RecordScreenBottomSheetState.none) {
+            //       ref
+            //           .read(recordScreenViewmodelProvider.notifier)
+            //           .closeBottomSheet();
+            //       Navigator.of(context).pop();
+            //     }
+            //   },
+            // ),
             Expanded(
               child: TabBarView(
                 physics: const NeverScrollableScrollPhysics(),

--- a/lib/presentation/viewmodels/user/my_page_viewmodel.dart
+++ b/lib/presentation/viewmodels/user/my_page_viewmodel.dart
@@ -8,7 +8,7 @@ import '../shared/exception_handler_on_viewmodel.dart';
 
 part 'my_page_viewmodel.g.dart';
 
-class MyPageState {
+class MyPageStateModel {
   /// Profile
   final String name;
   final String generation;
@@ -26,7 +26,7 @@ class MyPageState {
   /// Record
   final List<({BoulderLevel level, int count})> boulderProblems;
 
-  const MyPageState({
+  const MyPageStateModel({
     required this.name,
     required this.generation,
     required this.role,
@@ -44,7 +44,7 @@ class MyPageState {
 @riverpod
 class MyPageViewmodel extends _$MyPageViewmodel {
   @override
-  Future<MyPageState> build() async {
+  Future<MyPageStateModel> build() async {
     logger.d('Execute MyPageViewModel');
     late final MyPageModel myPage;
     try {
@@ -55,9 +55,9 @@ class MyPageViewmodel extends _$MyPageViewmodel {
     return _fromMyPageModel(myPage);
   }
 
-  MyPageState _fromMyPageModel(MyPageModel myPage) {
+  MyPageStateModel _fromMyPageModel(MyPageModel myPage) {
     myPage.records.sort((a, b) => a.level.index.compareTo(b.level.index));
-    return MyPageState(
+    return MyPageStateModel(
       name: myPage.profile.name,
       generation: myPage.profile.generation,
       role: myPage.profile.role,


### PR DESCRIPTION
# Description
현재 시각 이후의 운동 기록을 생성하지 못하게 수정하였습니다.
기록하기 화면에서 기록 생성 및 수정 또는 기록 디테일 하단 바를 닫았을 때에도 포커스가 유지되게 하였습니다.

# Done
- [x] 현재 시각 이후의 종료 시각을 가진 운동 기록을 생성하지 못하게 Validator 추가.
- [x] 기록 화면의 달력 포커스가 현재 날짜로 돌아가지 않게 수정